### PR TITLE
Add example: create server with CentOS public archive

### DIFF
--- a/examples/server/.gitignore
+++ b/examples/server/.gitignore
@@ -1,0 +1,2 @@
+/bin/
+/node_modules/

--- a/examples/server/Pulumi.yaml
+++ b/examples/server/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: server
+runtime: nodejs
+description: A program for building Server on SakuraCloud with TypeScript

--- a/examples/server/index.ts
+++ b/examples/server/index.ts
@@ -1,0 +1,18 @@
+import * as sakuracloud from "@sacloud/pulumi_sakuracloud";
+
+const centOSArchive = sakuracloud.getArchive({osType: "centos"});
+
+const disk = new sakuracloud.Disk("pulumi-example", {
+    name: "pulumi-example",
+    sourceArchiveId: centOSArchive.id,
+});
+
+const server = new sakuracloud.Server("pulumi-example", {
+    name: "pulumi-example",
+    disks: [disk.id],
+    password: "YourPassword01",
+});
+
+// Export the created resource' IDs
+export const serverID = server.id;
+export const diskID = disk.id;

--- a/examples/server/package.json
+++ b/examples/server/package.json
@@ -1,0 +1,10 @@
+{
+    "name": "typescript",
+    "devDependencies": {
+        "@types/node": "latest"
+    },
+    "dependencies": {
+        "@pulumi/pulumi": "^1.0.0",
+        "@sacloud/pulumi_sakuracloud": "^0.0.1"
+    }
+}

--- a/examples/server/tsconfig.json
+++ b/examples/server/tsconfig.json
@@ -1,0 +1,22 @@
+{
+    "compilerOptions": {
+        "outDir": "bin",
+        "target": "es6",
+        "lib": [
+            "es6"
+        ],
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "sourceMap": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitAny": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true,
+        "strictNullChecks": true
+    },
+    "files": [
+        "index.ts"
+    ]
+}


### PR DESCRIPTION
TypeScriptでサーバを作成する例を追加

- 最新安定板のCentOSパブリックアーカイブを利用してディスクを作成
- ディスクを接続するサーバを作成。ディスクの修正機能でパスワードを設定

```ts
import * as sakuracloud from "@sacloud/pulumi_sakuracloud";

const centOSArchive = sakuracloud.getArchive({osType: "centos"});

const disk = new sakuracloud.Disk("pulumi-example", {
    name: "pulumi-example",
    sourceArchiveId: centOSArchive.id,
});

const server = new sakuracloud.Server("pulumi-example", {
    name: "pulumi-example",
    disks: [disk.id],
    password: "YourPassword01",
});

// Export the created resource' IDs
export const serverID = server.id;
export const diskID = disk.id;

```